### PR TITLE
PYMT-1170: Invalid URI Action Exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor/
+*.cache

--- a/src/Sdk/Exceptions/InvalidUriActionException.php
+++ b/src/Sdk/Exceptions/InvalidUriActionException.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\SdkBlueprint\Sdk\Exceptions;
+
+use EoneoPay\Utils\Exceptions\ValidationException;
+
+/**
+ * An exception that is thrown when the request action does not exist under an entities supported URIs.
+ */
+class InvalidUriActionException extends ValidationException
+{
+    /**
+     * @inheritdoc
+     */
+    public function getErrorCode(): int
+    {
+        return self::DEFAULT_ERROR_CODE_VALIDATION;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getErrorSubCode(): int
+    {
+        return self::DEFAULT_ERROR_SUB_CODE + 1;
+    }
+}

--- a/tests/Sdk/Exceptions/InvalidUriActionExceptionTest.php
+++ b/tests/Sdk/Exceptions/InvalidUriActionExceptionTest.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\SdkBlueprint\Sdk\Exceptions;
+
+use EoneoPay\Utils\Interfaces\BaseExceptionInterface;
+use LoyaltyCorp\SdkBlueprint\Sdk\Exceptions\InvalidUriActionException;
+use Tests\LoyaltyCorp\SdkBlueprint\TestCase;
+
+/**
+ * @covers \LoyaltyCorp\SdkBlueprint\Sdk\Exceptions\InvalidUriActionException
+ */
+class InvalidUriActionExceptionTest extends TestCase
+{
+    /**
+     * Test that exception has expected code.
+     *
+     * @return void
+     */
+    public function testExceptionCodes(): void
+    {
+        $exception = new InvalidUriActionException();
+
+        self::assertSame(BaseExceptionInterface::DEFAULT_ERROR_CODE_VALIDATION, $exception->getErrorCode());
+        self::assertSame(1, $exception->getErrorSubCode());
+    }
+}

--- a/tests/Sdk/Handlers/RequestHandlerTest.php
+++ b/tests/Sdk/Handlers/RequestHandlerTest.php
@@ -103,7 +103,6 @@ class RequestHandlerTest extends TestCase
 
         $entityClass = new class extends Entity
         {
-
             /**
              * {@inheritdoc}
              */

--- a/tests/Sdk/Handlers/RequestHandlerTest.php
+++ b/tests/Sdk/Handlers/RequestHandlerTest.php
@@ -8,7 +8,9 @@ use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use LoyaltyCorp\SdkBlueprint\Sdk\Entity;
 use LoyaltyCorp\SdkBlueprint\Sdk\Exceptions\InvalidApiResponseException;
+use LoyaltyCorp\SdkBlueprint\Sdk\Exceptions\InvalidUriActionException;
 use LoyaltyCorp\SdkBlueprint\Sdk\Factories\SerializerFactory;
 use LoyaltyCorp\SdkBlueprint\Sdk\Factories\UrnFactory;
 use LoyaltyCorp\SdkBlueprint\Sdk\Handlers\RequestHandler;
@@ -88,17 +90,49 @@ class RequestHandlerTest extends TestCase
     }
 
     /**
+     * Tests that the request handler throws an exception when the request URI action is invalid.
+     *
+     * @return void
+     */
+    public function testInvalidActionThrowsException(): void
+    {
+        $this->expectException(InvalidUriActionException::class);
+        $this->expectExceptionMessage(
+            'The URI action (update) is invalid, or not supported for the specified resource.'
+        );
+
+        $entityClass = new class extends Entity
+        {
+
+            /**
+             * {@inheritdoc}
+             */
+            public function uris(): array
+            {
+                return [
+                    self::CREATE => '/create'
+                ];
+            }
+        };
+
+        $handler = $this->getHandler();
+        $handler->executeAndRespond($entityClass, RequestAwareInterface::UPDATE, 'api-key');
+    }
+
+    /**
      * Test that list method of request handler will list exepected number of entities.
      *
      * @return void
      */
     public function testList(): void
     {
-        $data = [[
-            'userId' => 'user-id',
-            'type' => 'customer',
-            'email' => 'customer@email.test'
-        ]];
+        $data = [
+            [
+                'userId' => 'user-id',
+                'type' => 'customer',
+                'email' => 'customer@email.test'
+            ]
+        ];
 
         $entities = $this->getHandler([
             new Response(200, [], \json_encode($data) ?: '')


### PR DESCRIPTION
In this PR, the `InvalidUriActionException` class has been crafted and the `RequestHandler` class updated to throw this exception where the provided `$action` does not exist in an entity's returned list of URIs.

**Please move the task back to TODO when reviewed.**