### PR TITLE
PYMT-1161: Serializer to SerializerInterface for SerializerFactory

### DIFF
--- a/src/Sdk/Factories/SerializerFactory.php
+++ b/src/Sdk/Factories/SerializerFactory.php
@@ -17,6 +17,7 @@ use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer;
+use Symfony\Component\Serializer\SerializerInterface;
 
 /**
  * @SuppressWarnings("PMD.StaticAccess") static access is required for annotation loader.
@@ -31,7 +32,7 @@ final class SerializerFactory implements SerializerFactoryInterface
      * @noinspection PhpDocMissingThrowsInspection
      * We don't add throw Annotation Exception in order to not catch it everywhere
      */
-    public function create(): Serializer
+    public function create(): SerializerInterface
     {
         /** @noinspection PhpDeprecationInspection currently this is the best way to register annotation loader */
         AnnotationRegistry::registerUniqueLoader('class_exists');

--- a/src/Sdk/Interfaces/Factories/SerializerFactoryInterface.php
+++ b/src/Sdk/Interfaces/Factories/SerializerFactoryInterface.php
@@ -3,14 +3,14 @@ declare(strict_types=1);
 
 namespace LoyaltyCorp\SdkBlueprint\Sdk\Interfaces\Factories;
 
-use Symfony\Component\Serializer\Serializer;
+use Symfony\Component\Serializer\SerializerInterface;
 
 interface SerializerFactoryInterface
 {
     /**
      * Factory method to create Symfony serializer.
      *
-     * @return \Symfony\Component\Serializer\Serializer
+     * @return \Symfony\Component\Serializer\SerializerInterface
      */
-    public function create(): Serializer;
+    public function create(): SerializerInterface;
 }


### PR DESCRIPTION
In the PR, I have updated the SerializerFactory to return a SerializerInterface type rather than a static Serializer type so that it can be stubbed for unit tests, or extended for other means.