### PR TITLE
[Defect] PYMT-1596: Empty Body Content

### DIFF
--- a/src/Sdk/Handlers/RequestHandler.php
+++ b/src/Sdk/Handlers/RequestHandler.php
@@ -105,7 +105,7 @@ final class RequestHandler implements RequestHandlerInterface
         // If the response content is blank, return an empty array
         $content = $response->getContent();
         if (\trim($content) === '') {
-            return [];
+            $content = '[]';
         }
 
         $type = (\mb_strtolower($action) === self::LIST)

--- a/tests/Sdk/Handlers/RequestHandlerTest.php
+++ b/tests/Sdk/Handlers/RequestHandlerTest.php
@@ -49,23 +49,6 @@ final class RequestHandlerTest extends TestCase
     }
 
     /**
-     * Get request handler.
-     *
-     * @param mixed[]|null $responses PSR-7 http responses
-     *
-     * @return \LoyaltyCorp\SdkBlueprint\Sdk\Interfaces\Handlers\RequestHandlerInterface
-     */
-    private function getHandler(?array $responses = null): RequestHandlerInterface
-    {
-        return new RequestHandler(
-            new GuzzleClient(['handler' => new MockHandler($responses)]),
-            new ResponseHandlerStub(),
-            new SerializerFactory(),
-            new UrnFactory()
-        );
-    }
-
-    /**
      * Test that delete an entity will return null.
      *
      * @return void
@@ -104,21 +87,20 @@ final class RequestHandlerTest extends TestCase
     }
 
     /**
-     * Perform assertion.
-     *
-     * @param mixed[] $expected Expected data
-     * @param \LoyaltyCorp\SdkBlueprint\Sdk\Interfaces\EntityInterface $entity
+     * Tests that the request handler gracefully handles empty response bodies.
      *
      * @return void
      */
-    private function performAssertion(array $expected, EntityInterface $entity): void
+    public function testHandlesEmptyResponse(): void
     {
-        self::assertInstanceOf(UserStub::class, $entity);
+        $data = [];
 
-        /** @var \Tests\LoyaltyCorp\SdkBlueprint\Stubs\Entities\UserStub $entity */
-        self::assertSame($expected['userId'], $entity->getUserId());
-        self::assertSame($expected['type'], $entity->getType());
-        self::assertSame($expected['email'], $entity->getEmail());
+        $handler = $this->getHandler([
+            new Response(200, [], '')
+        ]);
+        $entity = $handler->executeAndRespond(new EntityStub([]), RequestAwareInterface::GET, 'api-key');
+
+        self::assertSame($data, $entity);
     }
 
     /**
@@ -206,5 +188,40 @@ final class RequestHandlerTest extends TestCase
         ])), RequestAwareInterface::UPDATE, 'api-key');
 
         $this->performAssertion($data, $entity);
+    }
+
+    /**
+     * Get request handler.
+     *
+     * @param mixed[]|null $responses PSR-7 http responses
+     *
+     * @return \LoyaltyCorp\SdkBlueprint\Sdk\Interfaces\Handlers\RequestHandlerInterface
+     */
+    private function getHandler(?array $responses = null): RequestHandlerInterface
+    {
+        return new RequestHandler(
+            new GuzzleClient(['handler' => new MockHandler($responses)]),
+            new ResponseHandlerStub(),
+            new SerializerFactory(),
+            new UrnFactory()
+        );
+    }
+
+    /**
+     * Perform assertion.
+     *
+     * @param mixed[] $expected Expected data
+     * @param \LoyaltyCorp\SdkBlueprint\Sdk\Interfaces\EntityInterface $entity
+     *
+     * @return void
+     */
+    private function performAssertion(array $expected, EntityInterface $entity): void
+    {
+        self::assertInstanceOf(UserStub::class, $entity);
+
+        /** @var \Tests\LoyaltyCorp\SdkBlueprint\Stubs\Entities\UserStub $entity */
+        self::assertSame($expected['userId'], $entity->getUserId());
+        self::assertSame($expected['type'], $entity->getType());
+        self::assertSame($expected['email'], $entity->getEmail());
     }
 }

--- a/tests/Sdk/Handlers/RequestHandlerTest.php
+++ b/tests/Sdk/Handlers/RequestHandlerTest.php
@@ -93,14 +93,12 @@ final class RequestHandlerTest extends TestCase
      */
     public function testHandlesEmptyResponse(): void
     {
-        $data = [];
-
         $handler = $this->getHandler([
             new Response(200, [], '')
         ]);
-        $entity = $handler->executeAndRespond(new EntityStub([]), RequestAwareInterface::GET, 'api-key');
+        $entity = $handler->executeAndRespond(new UserStub([]), RequestAwareInterface::GET, 'api-key');
 
-        self::assertSame($data, $entity);
+        self::assertInstanceOf(UserStub::class, $entity);
     }
 
     /**


### PR DESCRIPTION
This PR adjusts the request handler to return an empty array where the response content body is blank. Other changes include automated code clean up by the IDE.

This is a part of a defect ticket to fix an issue with nominal initiation.

**Ticket**: https://eonx.atlassian.net/browse/PAY-1596